### PR TITLE
New way of history logging.

### DIFF
--- a/firebase.config.json
+++ b/firebase.config.json
@@ -8,16 +8,18 @@
       ".write": true,
       
       "$playersId": {
-        "$historyId": {
-          ".validate": "newData.hasChildren(['dateTime', 'winner', 'winnerOldScore', 'winnerNewScore', 'loser', 'loserOldScore', 'loserNewScore'])",
-          "$other":         { ".validate": false },
-          "dateTime":       { ".validate": "newData.isNumber()" },
-          "winner":         { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
-          "winnerOldScore": { ".validate": "newData.isNumber()" },
-          "winnerNewScore": { ".validate": "newData.isNumber()" },
-          "loser":          { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
-          "loserOldScore":  { ".validate": "newData.isNumber()" },
-          "loserNewScore":  { ".validate": "newData.isNumber()" }
+        "$monthYear" :{
+          "$historyId": {
+            ".validate": "newData.hasChildren(['dateTime', 'winner', 'winnerOldScore', 'winnerNewScore', 'loser', 'loserOldScore', 'loserNewScore'])",
+            "$other":         { ".validate": false },
+            "dateTime":       { ".validate": "newData.isNumber()" },
+            "winner":         { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
+            "winnerOldScore": { ".validate": "newData.isNumber()" },
+            "winnerNewScore": { ".validate": "newData.isNumber()" },
+            "loser":          { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
+            "loserOldScore":  { ".validate": "newData.isNumber()" },
+            "loserNewScore":  { ".validate": "newData.isNumber()" }
+          }
         }
       }
     },

--- a/firebase.config.json
+++ b/firebase.config.json
@@ -6,17 +6,19 @@
     "history": {
       ".read": true,
       ".write": true,
-
-      "$historyId": {
-        ".validate": "newData.hasChildren(['dateTime', 'winner', 'winnerOldScore', 'winnerNewScore', 'loser', 'loserOldScore', 'loserNewScore'])",
-        "$other":         { ".validate": false },
-        "dateTime":       { ".validate": "newData.isNumber()" },
-        "winner":         { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
-        "winnerOldScore": { ".validate": "newData.isNumber()" },
-        "winnerNewScore": { ".validate": "newData.isNumber()" },
-        "loser":          { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
-        "loserOldScore":  { ".validate": "newData.isNumber()" },
-        "loserNewScore":  { ".validate": "newData.isNumber()" }
+      
+      "$playersId": {
+        "$historyId": {
+          ".validate": "newData.hasChildren(['dateTime', 'winner', 'winnerOldScore', 'winnerNewScore', 'loser', 'loserOldScore', 'loserNewScore'])",
+          "$other":         { ".validate": false },
+          "dateTime":       { ".validate": "newData.isNumber()" },
+          "winner":         { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
+          "winnerOldScore": { ".validate": "newData.isNumber()" },
+          "winnerNewScore": { ".validate": "newData.isNumber()" },
+          "loser":          { ".validate": "newData.isString() && newData.val().length > 1 && newData.val().length < 100" },
+          "loserOldScore":  { ".validate": "newData.isNumber()" },
+          "loserNewScore":  { ".validate": "newData.isNumber()" }
+        }
       }
     },
 

--- a/src/components/game-table.jsx
+++ b/src/components/game-table.jsx
@@ -29,8 +29,6 @@ module.exports = React.createClass({
   componentWillMount() {
     // https://www.firebase.com/docs/web/libraries/react/api.html
     let fbPath = [conf.firebaseUrl, 'players'].join('/');
-    let fbPathHistory = [conf.firebaseUrl, 'history'].join('/');
-    this.fireBaseHistory = new Firebase(fbPathHistory);
     this.fireBase = new Firebase(fbPath);
     this.loadData(); // should update to bindAsObject/Array
   },
@@ -143,7 +141,16 @@ module.exports = React.createClass({
 
     else if(confirm("So you're saying " + winner.name + " beat " + loser.name + "?")) {
       this.fireBase.update(results);
-      this.fireBaseHistory.push(history);
+
+      let winnerUrl = [conf.firebaseUrl, 'history', winner.id].join('/');
+      let fireBaseWinnerHistory = new Firebase(winnerUrl);
+
+      fireBaseWinnerHistory.push(history);
+
+      let loserUrl = [conf.firebaseUrl, 'history', loser.id].join('/');
+      let fireBaseLoserHistory = new Firebase(loserUrl);
+
+      fireBaseLoserHistory.push(history);
     }
 
     this.setState({ winner: null, loser: null });

--- a/src/components/game-table.jsx
+++ b/src/components/game-table.jsx
@@ -142,14 +142,14 @@ module.exports = React.createClass({
     else if(confirm("So you're saying " + winner.name + " beat " + loser.name + "?")) {
       this.fireBase.update(results);
 
-      let winnerUrl = [conf.firebaseUrl, 'history', winner.id].join('/');
-      let fireBaseWinnerHistory = new Firebase(winnerUrl);
+      let date = [new Date().getFullYear(), new Date().getMonth()].join('_');
 
+      let winnerUrl = [conf.firebaseUrl, 'history', winner.id, date].join('/');
+      let fireBaseWinnerHistory = new Firebase(winnerUrl);
       fireBaseWinnerHistory.push(history);
 
-      let loserUrl = [conf.firebaseUrl, 'history', loser.id].join('/');
+      let loserUrl = [conf.firebaseUrl, 'history', loser.id, date].join('/');
       let fireBaseLoserHistory = new Firebase(loserUrl);
-
       fireBaseLoserHistory.push(history);
     }
 


### PR DESCRIPTION
History objects are now stored on a Player. It's separate from the 'Player' table to reduce the lookup time for rendering the Game-Table (other wise this lookup would get all a Players history every time the app loads.)

All the other History that has been logged since then will be lost.

When doing Stats Graphing you will then be able to do a quicker lookup for a Players entire history.

Your thoughts? A new Firebase object has to be created each time now, rather than reusing one.

When I redo the Abstraction branch I'll add this and the DELETE/EDIT player methods as you said in the other PR.
