### PR TITLE
Fixes SetState issue when navigating between routes with duplicate Firebase data listeners

### DIFF
--- a/src/components/GameTable.jsx
+++ b/src/components/GameTable.jsx
@@ -30,6 +30,10 @@ export const GameTable =  React.createClass({
     this.loadData(); // should update to bindAsObject/Array
   },
 
+  componentWillUnmount: function() {
+    this.firebase.unload();
+  },
+
   render() {
     return (
     <table className={"elo-ranking-table table table-striped " + ( this.state.loaded ? "loaded" : "") }>

--- a/src/components/PlayerDash.jsx
+++ b/src/components/PlayerDash.jsx
@@ -27,6 +27,10 @@ export const PlayerDash = React.createClass({
     this.loadData(); // should update to bindAsObject/Array
   },
 
+  componentWillUnmount: function() {
+    this.fireBase.off();
+  },
+
   render() {
     // console.log(this.state.players);
     const player = _.find(this.state.players, p => p.id == this.props.params.playerId);

--- a/src/utils/FirebaseLib.js
+++ b/src/utils/FirebaseLib.js
@@ -27,6 +27,11 @@ function fireBaseWrapper(){
   this.dataOn = function(eventType, callBack){
     this.fireBase.on(eventType, callBack);
   };
+
+  this.unload = function() {
+    this.fireBase.off();
+    this.fireBaseHistory.off();
+  };
 }
 
 module.exports = fireBaseWrapper;


### PR DESCRIPTION
@philals,

This fixes the issue documented at https://github.com/pjho/Elo-Score-Board/issues/9.

The Firebase data.on callback needs to be unloaded when component is unmounted - in our case when navigating between routes.
