### PR TITLE
Adds logic to gulp file to only minify JS for prod. Adds scripts to p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A simple scoreboard implementing the [Elo ranking system](https://en.wikipedia.o
 3. Copy `app.config.json.sample.txt` to `app.config.json`
 4. Update the `firebaseUrl` setting to point to your new Firebase App's url.
 5. > `npm install`
-6. > `gulp`
+6. > `npm run dev` || `npm run start` to develop
+6b > `npm run build` to build a distribution with minfied files.
+
 
 ### FireBase ###
 To setup serverside validation rules enter firebase.config.json rule set under the `Security & Rules` section of your Firebase dashboard.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ var gutil = require('gulp-util');
 var source = require('vinyl-source-stream');
 var browserify = require('browserify');
 var watchify = require('watchify');
-var babelify = require('babelify')
+var babelify = require('babelify');
 var notifier = require('node-notifier');
 var concat = require('gulp-concat');
 var sass = require('gulp-sass');
@@ -11,7 +11,9 @@ var minifyCss = require('gulp-minify-css');
 var watch = require('gulp-watch');
 var uglify = require('gulp-uglify');
 var buffer = require('vinyl-buffer');
-var browserSync = require('browser-sync')
+var browserSync = require('browser-sync');
+
+var prod = process.env.NODE_ENV == 'production';
 
 var notify = function(error) {
   var message = 'In: ';
@@ -31,8 +33,9 @@ var notify = function(error) {
   if(error.lineNumber) {
     message += '\nOn Line: ' + error.lineNumber;
   }
-  console.log(title);
-  console.log(message);
+
+  gutil.log(title);
+  gutil.log(message);
   notifier.notify({title: title, message: message});
 };
 
@@ -41,10 +44,10 @@ var bundler = watchify(browserify({
   entries: ['./src/app.jsx'],
   transform: [babelify],
   extensions: ['.jsx'],
-  debug: true,
+  debug: !prod,
   cache: {},
   packageCache: {},
-  fullPaths: true
+  fullPaths: !prod,
 }));
 
 function bundle() {
@@ -52,14 +55,13 @@ function bundle() {
     .on('error', notify)
     .pipe(source('main.js'))
     .pipe(buffer())
-    .pipe(uglify())
+    .pipe(prod ? uglify() : gutil.noop())
     .pipe(gulp.dest('./dist/'))
     .pipe(browserSync.stream());
 }
 
 bundler.on('update', bundle);
-gulp.task('js', function() { bundle(); });
-
+gulp.task('js', function() { return bundle(); });
 
 gulp.task('serve', function() {
     browserSync({
@@ -70,7 +72,7 @@ gulp.task('serve', function() {
 });
 
 gulp.task('sass', function () {
-  gulp.src('./sass/**/*.scss')
+  return gulp.src('./sass/**/*.scss')
     .pipe(sass().on('error', sass.logError))
     .pipe(concat('style.css'))
     .pipe(minifyCss())
@@ -79,12 +81,20 @@ gulp.task('sass', function () {
 });
 
 gulp.task('copy', function () {
-  gulp.src(['index.html','fonts/**/*'],{base:'./'})
+  return gulp.src(['index.html','fonts/**/*'],{base:'./'})
     .pipe(gulp.dest('./dist/'));
 });
-
-gulp.task('default', ['js', 'copy', 'serve', 'sass', 'watch']);
 
 gulp.task('watch', function () {
   gulp.watch('./sass/**/*.scss', ['sass']);
 });
+
+// use: npm run start
+gulp.task('default', ['js', 'copy', 'sass', 'serve', 'watch']);
+
+// use: npm run build
+gulp.task('build', ['js', 'copy', 'sass']);
+
+gulp.doneCallback = function (err) {
+  if( prod ) process.exit(err ? 1 : 0);
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "NODE_ENV=development gulp",
+    "start": "npm run dev",
+    "build": "NODE_ENV=production gulp build"
   },
   "author": "Pat Horsley",
   "license": "ISC",


### PR DESCRIPTION
…ackage.json to make it easy to run gulp in dev vs prod.

@philals 

This updates the Gulp task a bit. Nothing major but just gives us the ability to not minify JS while doing dev without having to comment/uncomment the minify process line in gulpfule.js.

It uses node environment variables to specify whether we are running in prod vs dev mode. Instead of calling `gulp` directly we can use `npm scripts` to call gulp with the environment variables set. I think you're deving on a mac right? On windows setting env vars is a little different. I've just put unix style scripts for now. Anyway... to use it:

`npm run dev` or `npm run start` - both do exactly what `gulp` does at the moment without the minify step. `start` is a fairly common standard, `dev` is more semantic so I prefer it but both for good measure.

`npm run build` builds the `dist` directory with minify and without starting the server.

Also you can still just call `gulp` directly if you prefer.
